### PR TITLE
Update config.json

### DIFF
--- a/dasshio/config.json
+++ b/dasshio/config.json
@@ -6,7 +6,7 @@
   "url": "https://github.com/danimtb/dasshio",
   "startup": "before",
   "boot": "auto",
-  "host_network": "True"
+  "host_network": "True",
   "options": {
     "buttons": [
       {


### PR DESCRIPTION
There was a missing comma in the config.json file that was preventing Hassio from downloading and installing the add-on. 