### PR TITLE
Update scapy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Here it is an example of a Dash Gillette button used to toggle a light and a Das
 
 ```json
 {
+  "timeout": 20,
   "buttons": [
   {
     "name": "Gillette",
@@ -79,6 +80,7 @@ Another possibility would be to use Dasshio to perform a HTTP Post request to an
 
 ```json
 {
+  "timeout": 20,
   "buttons": [
   {
     "name": "Gillette",

--- a/dasshio/requirements.txt
+++ b/dasshio/requirements.txt
@@ -1,3 +1,3 @@
 netifaces
 requests
-scapy-python3
+scapy>=2.4.0


### PR DESCRIPTION
scapy-python3 is an unofficial fork that is getting very oudated (many bug fixes missing).
Migrates to original and up-to-date scapy, which now supports both python 2 and 3